### PR TITLE
Default application creds

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
                          :extra-deps  {provisdom/test         {:git/url "https://github.com/Provisdom/test.git"
                                                                :sha     "f6a10aa33d7cafacd78ea948b99f24b9a6b5ed30"}
                                        org.clojure/test.check {:mvn/version "1.0.0"}}}
-           :test-runner {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-565"}}
+           :test-runner {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-601"}}
                          :main-opts  ["-m" "kaocha.runner"]}
            :dev         {:extra-paths ["resources" "env"]
                          :extra-deps  {com.climate/claypoole               {:mvn/version "1.1.4"}

--- a/src/compute/gcp/api.clj
+++ b/src/compute/gcp/api.clj
@@ -4,6 +4,7 @@
     [clojure.core.async :as async]
     [compute.gcp.impl.descriptor :as descriptors]
     [compute.gcp.impl.client :as client-impl]
+    [compute.gcp.credentials :as creds]
     [compute.gcp.async.api :as async.api]))
 
 (def ^:private *default-http-client
@@ -16,7 +17,8 @@
 
 (defn client
   [{:keys [api version http-client credentials-provider]}]
-  (let [descriptor (descriptors/load-descriptor api version)]
+  (let [descriptor (descriptors/load-descriptor api version)
+        credentials-provider (or credentials-provider (creds/get-default))]
     {::http-client          (or http-client (default-http-client))
      ::api-descriptor       descriptor
      ::credentials-provider credentials-provider}))


### PR DESCRIPTION
The `client` function currently requires the user to pass in a credentials provider. This PR uses the [application default credentials](https://github.com/googleapis/google-auth-library-java#application-default-credentials) when no credentials provider is passed in.

Note the paths that the application default credentials run through are: 

1. Credentials file pointed to by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
2. Credentials provided by the Google Cloud SDK `gcloud auth application-default login` command
3. Google App Engine built-in credentials
4. Google Cloud Shell built-in credentials
5. Google Compute Engine built-in credentials
6. Skip this check by setting the environment variable `NO_GCE_CHECK=true`
7. Customize the GCE metadata server address by setting the environment variable GCE_METADATA_HOST=<hostname>

Running `gcloud init` seemingly does not initialize things in the way application default credentials expects. You will need to run `gcloud auth application-default login` to get things to work correctly. 